### PR TITLE
feat: Add tool-cache checking function

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -111,3 +111,22 @@ export async function install_nextflow(
 
   return temp_install_dir
 }
+
+export function check_cache(version: string): boolean {
+  const cleaned_version = semver.clean(version, true)
+  if (cleaned_version === null) {
+    return false
+  }
+  const resolved_version = String(cleaned_version)
+
+  const nf_path = tc.find("nextflow", resolved_version)
+  if (!nf_path) {
+    core.debug(`Could not find Nextflow ${resolved_version} in the tool cache`)
+    return false
+  } else {
+    core.debug(`Found Nextflow ${resolved_version} at path '${nf_path}'`)
+    core.debug(`Adding '${nf_path}' to PATH`)
+    core.addPath(nf_path)
+    return true
+  }
+}


### PR DESCRIPTION
Partially fixes #5 

### What it does do

Caches all Nextflow installs when given explicit version numbers so that these installs do not have to hit the GitHub API

### What it doesn't do

Cache any reference to "latest-*". The whole point of these is that they need to check to see if they are, in fact, latest, so I don't see a good way around this.

> There are two hard things in computer science: naming and cache invalidation.

This relieves approx. 1/3 of nf-core's API calls within GitHub actions. Any feedback on how to manage the whole cache invalidation thing would be welcome, but I think our time will be better spent creating a better test grid system that can leverage multiple tests per Nextflow install (maybe nf-test can do this, maybe we just need to spend more time working out details within GitHub actions, idk at this point).