### PR TITLE
Add try catch to fs.renameSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- If `fs.renameSync` fails (e.g. because source and destination files are on different partitions), try `fs.copySync` and `fs.unlinkSync` instead (#14).
+
 ## [1.3.0] - 2023-05-19
 
 ## Changed

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -106,7 +106,13 @@ export async function install_nextflow(
   const temp_install_dir = fs.mkdtempSync(`nxf-${version}`)
   const nf_path = `${temp_install_dir}/nextflow`
 
-  fs.renameSync(nf_dl_path, nf_path)
+  try {
+    fs.renameSync(nf_dl_path, nf_path)
+  } catch (err: unknown) {
+    core.debug(`Failed to rename file: ${err}`)
+    fs.copyFileSync(nf_dl_path, nf_path)
+    fs.unlinkSync(nf_dl_path)
+  }
   fs.chmodSync(nf_path, "0711")
 
   return temp_install_dir


### PR DESCRIPTION
Accidentally closed #13.

Changes: 

* If `fs.renameSync` fails (e.g. because source and destination files are on different partitions), try `fs.copySync` and `fs.unlinkSync` instead (#14).