### PR TITLE
Fix testing ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,5 +23,6 @@ jobs:
       - run: npm run format:check
       - run: npm run lint
       - run: npm run package
-      # FIXME Token doesn't get passed correctly
-      # - run: npm run test
+      - run: npm run test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Re-enable npm run test in CI (#15).
 
+- Fix release version check in unit test (#15).
+
 ## [1.3.0] - 2023-05-19
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - If `fs.renameSync` fails (e.g. because source and destination files are on different partitions), try `fs.copySync` and `fs.unlinkSync` instead (#14).
 
+## Fixed
+
+- Re-enable npm run test in CI (#15).
+
 ## [1.3.0] - 2023-05-19
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix release version check in unit test (#15).
 
+- Add helper function for checking the latest releases in the unit tests (#15).
+
 ## [1.3.0] - 2023-05-19
 
 ## Changed

--- a/test/functions.ts
+++ b/test/functions.ts
@@ -3,7 +3,7 @@ import { GitHub } from "@actions/github/lib/utils"
 import anyTest, { TestFn } from "ava" // eslint-disable-line import/no-unresolved
 
 import * as functions from "../src/functions"
-import { getToken } from "./utils"
+import { getReleaseTag, getToken } from "./utils"
 
 const test = anyTest as TestFn<{
   token: string
@@ -29,7 +29,8 @@ test("lastest_stable_release_data", async t => {
     t.context["octokit"]
   )
   t.is(typeof result, "object")
-  t.is(result["tag_name"], "v23.04.2")
+  const expected = await getReleaseTag("nextflow-io/nextflow", false)
+  t.is(result["tag_name"], expected)
 })
 
 test.todo("nextflow_bin_url")

--- a/test/functions.ts
+++ b/test/functions.ts
@@ -29,7 +29,7 @@ test("lastest_stable_release_data", async t => {
     t.context["octokit"]
   )
   t.is(typeof result, "object")
-  t.is(result["tag_name"], "v22.10.2")
+  t.is(result["tag_name"], "v23.04.2")
 })
 
 test.todo("nextflow_bin_url")

--- a/test/releasedata.ts
+++ b/test/releasedata.ts
@@ -25,6 +25,6 @@ const macro = test.macro(async (t, version: string, expected: string) => {
 })
 
 test("hard version", macro, "v22.10.2", "v22.10.2")
-test("latest-stable", macro, "latest-stable", "v22.10.2")
-test("latest-edge", macro, "latest-edge", "v22.09.7-edge")
-test("latest-everything", macro, "latest-everything", "v22.10.2")
+test("latest-stable", macro, "latest-stable", "v23.04.2")
+test("latest-edge", macro, "latest-edge", "v23.06.0-edge")
+test("latest-everything", macro, "latest-everything", "v23.06.0-edge")

--- a/test/releasedata.ts
+++ b/test/releasedata.ts
@@ -3,7 +3,7 @@ import { GitHub } from "@actions/github/lib/utils"
 import anyTest, { TestFn } from "ava" // eslint-disable-line import/no-unresolved
 
 import { release_data } from "../src/functions"
-import { getToken } from "./utils"
+import { getReleaseTag, getToken } from "./utils"
 
 const test = anyTest as TestFn<{
   token: string
@@ -19,12 +19,22 @@ test.before(t => {
   }
 })
 
-const macro = test.macro(async (t, version: string, expected: string) => {
+const macro = test.macro(async (t, version: string) => {
+  let expected
+  if (version === "latest-stable") {
+    expected = await getReleaseTag("nextflow-io/nextflow", false)
+  } else if (version === "latest-edge") {
+    expected = await getReleaseTag("nextflow-io/nextflow", true)
+  } else if (version === "latest-everything") {
+    expected = await getReleaseTag("nextflow-io/nextflow", undefined)
+  } else {
+    expected = version
+  }
   const result = await release_data(version, t.context["octokit"])
   t.is(result["tag_name"], expected)
 })
 
-test("hard version", macro, "v22.10.2", "v22.10.2")
-test("latest-stable", macro, "latest-stable", "v23.04.2")
-test("latest-edge", macro, "latest-edge", "v23.06.0-edge")
-test("latest-everything", macro, "latest-everything", "v23.06.0-edge")
+test("hard version", macro, "v22.10.2")
+test("latest-stable", macro, "latest-stable")
+test("latest-edge", macro, "latest-edge")
+test("latest-everything", macro, "latest-everything")

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,3 +1,5 @@
+import fetch from "node-fetch"
+
 export function getToken(first: boolean): string {
   const token = process.env["GITHUB_TOKEN"] || ""
   if (!token && first) {
@@ -9,4 +11,32 @@ export function getToken(first: boolean): string {
   }
 
   return token
+}
+
+/**
+ * Retrieves the release from a GitHub repository. This function allows to fetch
+ * either the latest release or the latest pre-release ("edge" release).
+ *
+ * @param {string} repo - The GitHub repository to fetch the release from,
+ * in the format 'owner/repo'.
+ * @param {boolean} [prerelease] - If true, fetches the latest pre-release.
+ * If false or undefined, fetches the latest release regardless of whether
+ * it's a pre-release or not.
+ *
+ * @returns {Promise<string>} A Promise that resolves to a string representing the tag name
+ * of the found release. If no release is found, the Promise resolves to 'Release not found'.
+ */
+export async function getReleaseTag(
+  repo: string,
+  prerelease?: boolean
+): Promise<string> {
+  const response = await fetch(`https://api.github.com/repos/${repo}/releases`)
+  const releases = await response.json()
+
+  const release = releases.find(
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    (rel: any) => prerelease === undefined || rel.prerelease === prerelease
+  )
+
+  return release ? release.tag_name : "No release found"
 }


### PR DESCRIPTION
This re-enables npm run test in the CI. It turns out that the `npm run test` currently does not succeed, so that has to be fixed separately from this PR.

## Fixed

- Re-enable npm run test in CI (#15).