### PR TITLE
Fix 'Input does not meet YAML 1.2 "Core Schema" specification' error in ci

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -56,7 +56,4 @@ jobs:
       - run: npm run build
       - run: npm run package
       - uses: ./
-        with:
-          version: ${{ matrix.nextflow_version }}
-          all: ${{ matrix.all_distribution }}
       - run: nextflow -v


### PR DESCRIPTION
This CI is failing because no matrix specified for step 'test-14', so it can't find a value for nextflow_version and all_distribution.

I simply removed the arguments because I don't think it makes sense to test this against all versions of Nextflow.