### PR TITLE
Fail instead of warn, when `nextflow help` doesn't work

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -94,9 +94,8 @@ async function run(): Promise<void> {
     await exec.exec("nextflow", ["help"])
   } catch (e: unknown) {
     if (e instanceof Error) {
-      core.warning(
-        "Nextflow appears to have installed correctly, but an error was thrown while running it."
-      )
+      // fail workflow if Nextflow run does not succeed
+      core.setFailed(`Could not run 'nextflow help'. Error: ${e.message}`)
     }
   }
 }


### PR DESCRIPTION
While testing the AWS-based runners, this action repeatedly failed quietly, because Java was not installed, leading to not helpful error messages downstream: https://github.com/nf-core/modules/actions/runs/6480150371/job/17595232020

This change should at least stop the GHA when nextflow can't run.