### PR TITLE
Add lazy loading for GitHub API calls

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: "npm"
       - run: npm ci
       - run: npm run build
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: "npm"
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: "npm"
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: "npm"
       - run: npm ci
       - run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- API calls are now lazy loaded to avoid making unnecessary calls
+
 ## [1.5.0] - 2024-01-22
 
 ### Added

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -6,34 +6,6 @@ import semver from "semver"
 
 import { NextflowRelease } from "./nextflow-release"
 
-function tag_filter(version: string): (r: NextflowRelease) => Boolean {
-  // Setup tag-based filtering
-  let filter = (r: NextflowRelease): boolean => {
-    return semver.satisfies(r.versionNumber, version, true)
-  }
-
-  // Check if the user passed a 'latest*' tag, and override filtering
-  // accordingly
-  if (version.includes("latest")) {
-    if (version.includes("-everything")) {
-      // No filtering
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      filter = (r: NextflowRelease) => {
-        return true
-      }
-    } else if (version.includes("-edge")) {
-      filter = (r: NextflowRelease) => {
-        return r.versionNumber.endsWith("-edge")
-      }
-    } else {
-      filter = (r: NextflowRelease) => {
-        return !r.isEdge
-      }
-    }
-  }
-  return filter
-}
-
 async function get_latest_everything_nextflow_release(
   releases: AsyncGenerator<NextflowRelease>
 ): Promise<NextflowRelease> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,8 @@ import {
 import { NextflowRelease } from "./nextflow-release"
 import {
   pull_latest_stable_release,
-  setup_octokit,
-  release_iter
+  pull_releases,
+  setup_octokit
 } from "./octokit-wrapper"
 
 async function run(): Promise<void> {
@@ -43,7 +43,7 @@ async function run(): Promise<void> {
     if (version === "latest" || version === "latest-stable") {
       release = await pull_latest_stable_release(octokit)
     } else {
-      const release_iterator = release_iter(octokit)
+      const release_iterator = pull_releases(octokit)
       release = await get_nextflow_release(version, release_iterator)
     }
     resolved_version = release.versionNumber

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,11 @@ import {
   install_nextflow
 } from "./functions"
 import { NextflowRelease } from "./nextflow-release"
-import { pull_releases, setup_octokit } from "./octokit-wrapper"
+import {
+  pull_releases,
+  pull_latest_stable_release,
+  setup_octokit
+} from "./octokit-wrapper"
 
 async function run(): Promise<void> {
   // CAPSULE_LOG leads to a bunch of boilerplate being output to the logs: turn
@@ -32,13 +36,16 @@ async function run(): Promise<void> {
   // Setup the API
   const octokit = await setup_octokit(token, cooldown, max_retries)
 
-  const releases = await pull_releases(octokit)
-
   // Get the release info for the desired release
   let release = {} as NextflowRelease
   let resolved_version = ""
   try {
-    release = await get_nextflow_release(version, releases)
+    if (version === "latest" || version === "latest-stable") {
+      release = await pull_latest_stable_release(octokit)
+    } else {
+      const releases = await pull_releases(octokit)
+      release = await get_nextflow_release(version, releases)
+    }
     resolved_version = release.versionNumber
     core.info(
       `Input version '${version}' resolved to Nextflow ${release["name"]}`

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,9 +11,9 @@ import {
 } from "./functions"
 import { NextflowRelease } from "./nextflow-release"
 import {
-  pull_releases,
   pull_latest_stable_release,
-  setup_octokit
+  setup_octokit,
+  release_iter
 } from "./octokit-wrapper"
 
 async function run(): Promise<void> {
@@ -43,8 +43,8 @@ async function run(): Promise<void> {
     if (version === "latest" || version === "latest-stable") {
       release = await pull_latest_stable_release(octokit)
     } else {
-      const releases = await pull_releases(octokit)
-      release = await get_nextflow_release(version, releases)
+      const release_iterator = release_iter(octokit)
+      release = await get_nextflow_release(version, release_iterator)
     }
     resolved_version = release.versionNumber
     core.info(

--- a/src/octokit-wrapper.ts
+++ b/src/octokit-wrapper.ts
@@ -4,7 +4,7 @@ import { throttling } from "@octokit/plugin-throttling"
 
 import { nextflow_release, NextflowRelease } from "./nextflow-release"
 
-const NEXTFLOW_REPO = { owner: "nextflow-io", repo: "nextflow" }
+const NEXTFLOW_REPO = { owner: "nextflow-io", repo: "nextflow", per_page: 100 }
 
 export async function setup_octokit(
   github_token: string,

--- a/src/octokit-wrapper.ts
+++ b/src/octokit-wrapper.ts
@@ -51,7 +51,7 @@ export async function setup_octokit(
   return octokit
 }
 
-export async function* release_iter(
+export async function* pull_releases(
   octokit: InstanceType<typeof GitHub>
 ): AsyncGenerator<NextflowRelease> {
   const iterator = octokit.paginate.iterator(
@@ -75,23 +75,6 @@ export async function* release_iter(
     }
     yield nextflow_release(release_items[item_index++])
   }
-}
-
-export async function pull_releases(
-  ok: InstanceType<typeof GitHub>
-): Promise<NextflowRelease[]> {
-  return await ok.paginate(
-    ok.rest.repos.listReleases,
-    NEXTFLOW_REPO,
-    response => {
-      const all_releases: NextflowRelease[] = []
-      const releases_data = response.data
-      for (const release_data of releases_data) {
-        all_releases.push(nextflow_release(release_data))
-      }
-      return all_releases
-    }
-  )
 }
 
 export async function pull_latest_stable_release(

--- a/src/octokit-wrapper.ts
+++ b/src/octokit-wrapper.ts
@@ -4,7 +4,14 @@ import { throttling } from "@octokit/plugin-throttling"
 
 import { nextflow_release, NextflowRelease } from "./nextflow-release"
 
-const NEXTFLOW_REPO = { owner: "nextflow-io", repo: "nextflow", per_page: 100 }
+const NEXTFLOW_REPO = {
+  owner: "nextflow-io",
+  repo: "nextflow",
+  per_page: 100,
+  headers: {
+    "x-github-api-version": "2022-11-28"
+  }
+}
 
 export async function setup_octokit(
   github_token: string,

--- a/src/octokit-wrapper.ts
+++ b/src/octokit-wrapper.ts
@@ -68,19 +68,12 @@ export async function pull_releases(
   )
 }
 
-export async function latest_stable_release_data(
+export async function pull_latest_stable_release(
   ok: InstanceType<typeof GitHub>
-): Promise<object> {
+): Promise<NextflowRelease> {
   const { data: stable_release } = await ok.rest.repos.getLatestRelease(
     NEXTFLOW_REPO
   )
 
-  return stable_release
-}
-
-export async function pull_latest_stable_release(
-  ok: InstanceType<typeof GitHub>
-): Promise<NextflowRelease> {
-  const latest_release = await latest_stable_release_data(ok)
-  return nextflow_release(latest_release)
+  return nextflow_release(stable_release)
 }

--- a/src/octokit-wrapper.ts
+++ b/src/octokit-wrapper.ts
@@ -52,24 +52,19 @@ export async function setup_octokit(
 }
 
 export async function pull_releases(
-  octokit: InstanceType<typeof GitHub>
-): Promise<NextflowRelease[]> {
-  const all_release_data: object[] = await all_nf_release_data(octokit)
-  const all_releases: NextflowRelease[] = []
-  for (const data of all_release_data) {
-    all_releases.push(nextflow_release(data))
-  }
-
-  return all_releases
-}
-
-export async function all_nf_release_data(
   ok: InstanceType<typeof GitHub>
-): Promise<object[]> {
+): Promise<NextflowRelease[]> {
   return await ok.paginate(
     ok.rest.repos.listReleases,
     NEXTFLOW_REPO,
-    response => response.data
+    response => {
+      const all_releases: NextflowRelease[] = []
+      const releases_data = response.data
+      for (const release_data of releases_data) {
+        all_releases.push(nextflow_release(release_data))
+      }
+      return all_releases
+    }
   )
 }
 

--- a/src/octokit-wrapper.ts
+++ b/src/octokit-wrapper.ts
@@ -65,23 +65,15 @@ export async function* release_iter(
   const { next } = iterator[Symbol.asyncIterator]()
 
   let request = await next()
+  release_items = request.value.data
 
-  return {
-    async next() {
-      if (item_index >= release_items.length) {
-        if (request.done) {
-          return { done: true }
-        }
-
-        request = await next()
-        release_items = request.value.data
-        item_index = 0
-      }
-      return {
-        value: nextflow_release(release_items[item_index++]),
-        done: false
-      }
+  while (true) {
+    if (item_index > release_items.length) {
+      request = await next()
+      release_items = request.value.data
+      item_index = 0
     }
+    yield nextflow_release(release_items[item_index++])
   }
 }
 

--- a/test/functions.ts
+++ b/test/functions.ts
@@ -21,16 +21,17 @@ function nf_release_gen(version_number: string): NextflowRelease {
 }
 
 // A mock set of Nextflow releases
-const edge_is_newer = [
-  nf_release_gen("v23.09.1-edge"),
-  nf_release_gen("v23.04.3"),
-  nf_release_gen("v23.04.2")
-]
-const edge_is_older = [
-  nf_release_gen("v23.04.3"),
-  nf_release_gen("v23.04.2"),
-  nf_release_gen("v23.03.0-edge")
-]
+async function* edge_is_newer(): AsyncGenerator<NextflowRelease> {
+  yield nf_release_gen("v23.09.1-edge")
+  yield nf_release_gen("v23.04.3")
+  yield nf_release_gen("v23.04.2")
+}
+
+async function* edge_is_older(): AsyncGenerator<NextflowRelease> {
+  yield nf_release_gen("v23.04.3")
+  yield nf_release_gen("v23.04.2")
+  yield nf_release_gen("v23.03.0-edge")
+}
 
 /*
   The whole reason this action exists is to handle the cases where a final
@@ -44,7 +45,7 @@ const release_filter_macro = test.macro(
     t,
     input_version: string,
     expected_version: string,
-    releases: NextflowRelease[]
+    releases: AsyncGenerator<NextflowRelease>
   ) => {
     const matched_release = await functions.get_nextflow_release(
       input_version,
@@ -58,56 +59,56 @@ test(
   release_filter_macro,
   "latest-everything",
   "v23.09.1-edge",
-  edge_is_newer
+  edge_is_newer()
 )
 test(
   "Latest-everything install with older edge release",
   release_filter_macro,
   "latest-everything",
   "v23.04.3",
-  edge_is_older
+  edge_is_older()
 )
 test(
   "Latest-edge install with newer edge release",
   release_filter_macro,
   "latest-edge",
   "v23.09.1-edge",
-  edge_is_newer
+  edge_is_newer()
 )
 test(
   "Latest-edge install with older edge release",
   release_filter_macro,
   "latest-edge",
   "v23.03.0-edge",
-  edge_is_older
+  edge_is_older()
 )
 test(
   "Latest-stable install with newer edge release",
   release_filter_macro,
   "latest",
   "v23.04.3",
-  edge_is_newer
+  edge_is_newer()
 )
 test(
   "Latest-stable install with older edge release",
   release_filter_macro,
   "latest",
   "v23.04.3",
-  edge_is_older
+  edge_is_older()
 )
 test(
   "Fully versioned tag release",
   release_filter_macro,
   "v23.04.2",
   "v23.04.2",
-  edge_is_newer
+  edge_is_newer()
 )
 test(
   "Partially versioned tag release",
   release_filter_macro,
   "v23.04",
   "v23.04.3",
-  edge_is_newer
+  edge_is_newer()
 )
 
 test.todo("install_nextflow")

--- a/test/releasedata.ts
+++ b/test/releasedata.ts
@@ -2,8 +2,11 @@ import * as github from "@actions/github"
 import { GitHub } from "@actions/github/lib/utils"
 import anyTest, { TestFn } from "ava" // eslint-disable-line import/no-unresolved
 
-import { nextflow_bin_url } from "../src/nextflow-release"
-import { all_nf_release_data } from "../src/octokit-wrapper"
+import { NextflowRelease } from "../src/nextflow-release"
+import {
+  pull_latest_stable_release,
+  pull_releases
+} from "../src/octokit-wrapper"
 import { getToken } from "./utils"
 
 const test = anyTest as TestFn<{


### PR DESCRIPTION
Sorry if it seems like I'm polishing the silverware on the Titanic right now...but I was discovered some additional features while playing around in the code base that I thought would be helpful as a holdover for the time while I figure out how to completely switch the API.

There are some configuration and optimization changes that help make API pagination more efficient in this PR, but those are just prerequisites for the main feature: lazy loading. On the master branch right now, the action makes $N / 30$ API calls, where $N$ is the number of total Nextflow releases, no matter which release you are requesting. By implementing this PR, the action only calls the API until it finds a matching release (or can confirm that the release meets all requirements, in the case of `latest-everything`). This cuts the number of API calls down to _a third_ of their previous value (and that's for the old Nextflow versions that aren't returned on the first call).

Number of API calls performed by `act -j test`
| master | This PR |
| --- | --- |
| 157 | 45 |