### PR TITLE
ci: Update CI workflows to be compatible with act

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,3 @@
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+-s GITHUB_TOKEN
+--container-architecture linux/amd64

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -37,6 +37,11 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run package
+      - uses: actions/setup-java@v2
+        if: ${{ env.ACT }}
+        with:
+          java-version: 11
+          distribution: zulu
       - uses: ./
         with:
           version: ${{ matrix.nextflow_version }}
@@ -55,5 +60,10 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run package
+      - uses: actions/setup-java@v2
+        if: ${{ env.ACT}}
+        with:
+          java-version: 11
+          distribution: zulu
       - uses: ./
       - run: nextflow -v

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -10,7 +10,7 @@ on:
     types: [published]
 
 jobs:
-  test:
+  example-usage:
     runs-on: ubuntu-latest
 
     strategy:
@@ -43,7 +43,7 @@ jobs:
           all: ${{ matrix.all_distribution }}
       - run: nextflow -v
 
-  test-14:
+  example-maximized-build-space:
     runs-on: ubuntu-latest
     steps:
       - uses: easimon/maximize-build-space@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CI workflow steps for better compatibility with <https://github.com/nektos/act>
+
 ## [1.5.1] - 2024-01-30
 
 ### Changed


### PR DESCRIPTION
I've used act for a while now, and it's become more and more indispensable as I dive into the deep bowls of Github Actions. I got tired of constantly `git stash` and `git stash pop`ing these changes, and thought they would be useful for others.