### PR TITLE
Add deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI workflow steps for better compatibility with <https://github.com/nektos/act>
 - Visual Studio Code debugging configuration
 - Husky pre-commit hooks for linting and formatting
+- Deprecation messages to warn users of upcoming API switch
 
 ## [1.5.1] - 2024-01-30
 

--- a/action.yml
+++ b/action.yml
@@ -14,14 +14,18 @@ inputs:
     description: "GitHub token to access the GitHub Releases API. The default token should be sufficient for all use cases."
     required: false
     default: ${{ github.token }}
+    deprecationMessage: "setup-nextflow@v2 will no longer use the GitHub API. A token will no longer be needed."
   cooldown:
     description: "Time (in seconds) to wait before querying the GitHub Releases API in the case of hitting a rate limit."
     required: false
     default: "60"
+    deprecationMessage: "setup-nextflow@v2 will no longer use the GitHub API. The cooldown will no longer apply."
   max-retries:
     description: "The number of times that to try querying the GitHub Releases API in case of a rate-limited failure."
     required: false
     default: "3"
+    deprecationMessage: "setup-nextflow@v2 will no longer use the GitHub API. The retry count will no longer apply."
+
 runs:
   using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
What it says on the box: warn users we're moving to a new API and won't need their tokens anymore. Merge after #36.