### PR TITLE
Update node version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded GitHub Actions node version to v20
+
 ## [1.5.2] - 2024-02-07
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     deprecationMessage: "setup-nextflow@v2 will no longer use the GitHub API. The retry count will no longer apply."
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "shuffle"


### PR DESCRIPTION
Node 16 is deprecated: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/