### PR TITLE
ci: Enable Renovate automerge for npm

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,5 +4,13 @@
         "github>nf-core/ops//.github/renovate/default.json5",
         "config:recommended",
         "schedule:weekly"
+    ],
+    "packageRules": [
+        {
+            "matchManagers": ["npm"],
+            "automerge": true,
+            "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+            "schedule": ["before 5am daily"]
+        }
     ]
 }


### PR DESCRIPTION
The renovate bot has the ability to merge package changes that pass ci testing and follow semver minor updates (non-breaking changes). I've been merging renovate packages for the past six months or so with no problems that weren't caught using the test suite, so I feel confident in letting the bot take over merging.