### PR TITLE
Refactor to composite GitHub Action with setup-java

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -40,11 +40,6 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run package
-      - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4
-        if: ${{ env.ACT }}
-        with:
-          java-version: 11
-          distribution: zulu
       - uses: ./
         with:
           version: ${{ matrix.nextflow_version }}
@@ -63,10 +58,5 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run package
-      - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4
-        if: ${{ env.ACT}}
-        with:
-          java-version: 11
-          distribution: zulu
       - uses: ./
       - run: nextflow -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Composite GitHub Action now includes `setup-java` action with `java-version` (default `21`) and `java-distribution` (default `zulu`) inputs
+
+### Changed
+
+- Removed `setup-java` action from `.github/workflows/example.yml` as it is now part of the composite action
+
 ## [2.0.0] - 2024-03-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ There are three (technically four) aliases to assist in choosing up-to-date Next
 
 A boolean deciding whether to download the "all versions" distribution of Nextflow. May be useful for running tests against multiple versions downstream.
 
+### `java-version`
+
+> **default: `21`**
+
+A version string to specify the version of Java to use.
+
+### `java-distribution`
+
+> **default: `zulu`**
+
+A string to specify the Java distribution to use.
+
 ## Outputs
 
 There are no outputs from this action.

--- a/action.yml
+++ b/action.yml
@@ -47,9 +47,9 @@ runs:
     - name: Install Nextflow
       shell: bash
       run: node lib/src/main.js
-      with:
-        version: ${{ inputs.version }}
-        all: ${{ inputs.all }}
+      env:
+        VERSION: ${{ inputs.version }}
+        ALL: ${{ inputs.all }}
 
 branding:
   icon: "shuffle"

--- a/action.yml
+++ b/action.yml
@@ -3,16 +3,34 @@ description: "Install Nextflow and add it to the PATH"
 author: "nf-core"
 inputs:
   version:
-    description: "The Nextflow version to download (if necessary) and use. Example: 21.10.3"
+    description: "The Nextflow version to download and use."
     required: false
     default: "latest-stable"
   all:
-    description: "Whether to install every Nextflow release via the '-all' distribution."
+    description: "Whether to install every Nextflow release."
     required: false
     default: false
+  java-version:
+    description: "The Java version to use."
+    required: false
+    default: "21"
+  java-distribution:
+    description: "The Java distribution to use."
+    required: false
+    default: "zulu"
 runs:
-  using: "node20"
-  main: "dist/index.js"
+  using: "composite"
+  steps:
+    - name: Setup Java
+      uses: actions/setup-java@v2
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: ${{ inputs.java-distribution }}
+    - name: Run custom action
+      uses: ./
+      with:
+        version: ${{ inputs.version }}
+        all: ${{ inputs.all }}
 branding:
   icon: "shuffle"
   color: "green"

--- a/action.yml
+++ b/action.yml
@@ -30,14 +30,19 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: 20
-
-    - name: Install npm
-      shell: bash
-      run: npm i -g npm@10
+        cache: "npm"
 
     - name: Install dependencies
       shell: bash
       run: npm ci
+
+    - name: Install dependencies
+      shell: bash
+      run: npm run build
+
+    - name: Install dependencies
+      shell: bash
+      run: npm run package
 
     - name: Install Nextflow
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -26,11 +26,26 @@ runs:
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.java-distribution }}
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Install npm
+      shell: bash
+      run: npm i -g npm@10
+
+    - name: Install dependencies
+      shell: bash
+      run: npm ci
+
     - name: Install Nextflow
+      shell: bash
       run: node lib/src/main.js
       with:
         version: ${{ inputs.version }}
         all: ${{ inputs.all }}
+
 branding:
   icon: "shuffle"
   color: "green"

--- a/action.yml
+++ b/action.yml
@@ -26,8 +26,8 @@ runs:
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.java-distribution }}
-    - name: Run custom action
-      uses: ./
+    - name: Install Nextflow
+      run: node lib/src/main.js
       with:
         version: ${{ inputs.version }}
         all: ${{ inputs.all }}

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,8 +21,8 @@ async function run(): Promise<void> {
   core.exportVariable("CAPSULE_LOG", "none")
 
   // Read in the arguments
-  const version = core.getInput("version")
-  const get_all = core.getBooleanInput("all")
+  const version = process.env.VERSION;
+  const get_all = process.env.ALL;
 
   // Check the cache for the Nextflow version that matched last time
   if (check_cache(version)) {


### PR DESCRIPTION
Refactor the repository to be a composite GitHub Action that first runs the `setup-java` action and then the custom action.

* **action.yml**
  - Add a new input `java-version` with a default value of `21`.
  - Change the action to use a composite run with steps.
  - Add a step to run `actions/setup-java` with the `java-version` input.
  - Add a step to run the custom action with the existing inputs.

* **.github/workflows/example.yml**
  - Remove the `setup-java` action step.
  - Ensure the workflow uses the updated composite action.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nf-core/setup-nextflow/pull/174?shareId=c481e043-614b-467b-94e3-55d8df61d474).