### PR TITLE
chore: enforce ast-grep rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
       - run: npm run build
       - run: npm run format:check
       - run: npm run lint
+      - run: npm run ast-grep:test
+      - run: npm run ast-grep:scan
       - run: npm run package
       - name: Check dist is up to date
         run: |

--- a/ast-grep/rule-tests/require-js-extension-relative-import-test.yml
+++ b/ast-grep/rule-tests/require-js-extension-relative-import-test.yml
@@ -1,0 +1,10 @@
+id: require-js-extension-relative-import
+valid:
+  - import { foo } from "./foo.js"
+  - import type { Foo } from "../foo.js"
+  - export { foo } from "./foo.js"
+  - import foo from "foo"
+invalid:
+  - import { foo } from "./foo"
+  - import { foo } from "../foo"
+  - export { foo } from "./foo"

--- a/ast-grep/rules/require-js-extension-relative-import.yml
+++ b/ast-grep/rules/require-js-extension-relative-import.yml
@@ -1,0 +1,19 @@
+id: require-js-extension-relative-import
+language: TypeScript
+severity: error
+files:
+  - src/**/*.ts
+  - test/**/*.ts
+message: Relative imports must include the .js extension.
+note: TypeScript emits ESM; keep relative module specifiers executable by Node.js.
+rule:
+  all:
+    - kind: string
+    - regex: ^["']\.\.?/
+    - not:
+        regex: \.js["']$
+    - inside:
+        any:
+          - kind: import_statement
+          - kind: export_statement
+        stopBy: end

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "semver": "^7.7.4"
       },
       "devDependencies": {
+        "@ast-grep/cli": "0.44.1",
         "@ava/typescript": "6.0.0",
         "@tsconfig/node22": "22.0.5",
         "@types/async-retry": "1.4.9",
@@ -114,6 +115,152 @@
         "@actions/http-client": "^4.0.0",
         "@actions/io": "^3.0.0",
         "semver": "^7.7.3"
+      }
+    },
+    "node_modules/@ast-grep/cli": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.44.1.tgz",
+      "integrity": "sha512-wSjtu0/9xSYzzo/EW31w5pf1qB33tejYKmKXb2nBAlZ5PpYtOqwFmk9H1nywhjzO913beugsKAZYxrwciqW9AQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "ast-grep": "ast-grep",
+        "sg": "sg"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "optionalDependencies": {
+        "@ast-grep/cli-darwin-arm64": "0.44.1",
+        "@ast-grep/cli-darwin-x64": "0.44.1",
+        "@ast-grep/cli-linux-arm64-gnu": "0.44.1",
+        "@ast-grep/cli-linux-x64-gnu": "0.44.1",
+        "@ast-grep/cli-win32-arm64-msvc": "0.44.1",
+        "@ast-grep/cli-win32-ia32-msvc": "0.44.1",
+        "@ast-grep/cli-win32-x64-msvc": "0.44.1"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-arm64": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.44.1.tgz",
+      "integrity": "sha512-wOzb+IqFy4Pdhvs+PeaHdQJ1VemsI1SgoOGJf+x0J0KBSJ+s/hUg2n1fVJwfsrw/XDIbz9m7PGKTGCLxsgYa1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-x64": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.44.1.tgz",
+      "integrity": "sha512-X3OzzsnO9Q3ISQ4qO3jasWk8EZhJA03xfmJHhuS9rGJZZCbNEuqjicrwrDMKK8EgEGJ7MG4oL0BE5qUcn3twLw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-arm64-gnu": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.44.1.tgz",
+      "integrity": "sha512-2F1YBRd9tQnfrGX+4BlkfXWLb2jqNgTmjp0ETLNRLMmSDinR905QsZn2A55qcAZxhQDU982mEzzgT4NduPXIGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-x64-gnu": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.44.1.tgz",
+      "integrity": "sha512-d5UNoDLT2i6xV4GGqcPnrAR6CB3H078+v3BiqjKxZdZMHFnDe46+i+DxfH1IK6yvJqViqv2F611+wiAAn/s7qw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-arm64-msvc": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.44.1.tgz",
+      "integrity": "sha512-r6K49Z14BLOeJdBSmaoK+TdgtPRqJfJ562F0n0KvRi0qH3o8is8N2dXtEMYKynYm/tdOd65i69Mc1WKSuIeWyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-ia32-msvc": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.44.1.tgz",
+      "integrity": "sha512-AusXTP5SfUQEL/EkF0fhHoA4H30M7hsVgvsVEZ7PeZrxB69trzUcqKnHC8pBDYTmgIsJsr9dtXjTPDcBauaPiA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-x64-msvc": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.44.1.tgz",
+      "integrity": "sha512-gDMHT17Edmp/tXTDdMSQHd9vJki2Y2WSXq9ycrvjziHwpmnsnc6xlCQ7SEOGA1987vepSpkOkqBCPliP2TVW0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@ava/typescript": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "format:check": "prettier --check '**/*.{ts,js,yml,md,json}'",
     "lint": "eslint {src,test}/**/*.ts",
     "lint:fix": "eslint --fix {src,test}/**/*.ts",
+    "ast-grep:test": "ast-grep test --skip-snapshot-tests",
+    "ast-grep:scan": "ast-grep scan",
     "package": "ncc build src/main.ts --source-map --license LICENSE",
     "test": "c8 --reporter=lcov ava",
-    "all": "npm run build && npm run format && npm run lint && npm run package && npm test",
+    "all": "npm run build && npm run format && npm run lint && npm run ast-grep:test && npm run ast-grep:scan && npm run package && npm test",
     "prepare": "husky"
   },
   "repository": {
@@ -47,6 +49,7 @@
     "semver": "^7.7.4"
   },
   "devDependencies": {
+    "@ast-grep/cli": "0.44.1",
     "@ava/typescript": "6.0.0",
     "@tsconfig/node22": "22.0.5",
     "@types/async-retry": "1.4.9",

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,4 @@
+ruleDirs:
+  - ast-grep/rules
+testConfigs:
+  - testDir: ast-grep/rule-tests


### PR DESCRIPTION
## Summary
- pin ast-grep and add project configuration
- enforce `.js` extensions on static relative TypeScript imports
- run rule tests and repository scans locally and in CI

## Verification
- `npm run build && npm run format:check && npm run lint && npm run ast-grep:test && npm run ast-grep:scan && npm test`
- `npm run all && npm run format:check`