### PR TITLE
chore(renovate): group eslint and test tooling updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,15 @@
             "automerge": true,
             "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
             "schedule": ["every weekday before 5am"]
+        },
+        // Order matters: later rules win, so eslint-plugin-ava lands in "test tooling"
+        {
+            "matchPackageNames": ["/eslint/"],
+            "groupName": "eslint"
+        },
+        {
+            "matchPackageNames": ["/ava/", "/^c8$/"],
+            "groupName": "test tooling"
         }
     ]
 }


### PR DESCRIPTION
## Summary

Groups related dev-dependency updates to reduce concurrent Renovate PRs:

- All eslint-family packages (`/eslint/`) → single **eslint** group PR
- `ava` and `c8` → single **test tooling** group PR

Rule order matters in `packageRules` (later rules win), so `eslint-plugin-ava` matches both patterns but lands in **test tooling**.

## Motivation

Renovate currently opens one PR per package (e.g. #228, #232, #239 all touching test/lint tooling separately). Grouping cuts PR noise and CI churn.

Split out from #245 to keep that PR focused on the release-time dist change.